### PR TITLE
Make layout responsive for mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 <html>
 <head>
 	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<title>The Finding of Isaac</title>
 	<link rel="stylesheet" type="text/css" href="thefindingofisaac.css">
 	<link rel="stylesheet" type="text/css" href="togglebutton.css">
@@ -59,9 +60,9 @@
 	<table id="hitsTable" cellPadding="3">
 		<tbody>
 			<tr>
-				<th style="width:150px">Name</th>
-				<th style="width:100px">Image</th>
-				<th style="width:100px">Type</th>
+				<th class="colMedium">Name</th>
+				<th class="colSmall">Image</th>
+				<th class="colSmall">Type</th>
 				<th>Description</th>
 			</tr>
 		</tbody>
@@ -71,8 +72,8 @@
 	<table id="hitsTable" cellPadding="3">
 		<tbody>
 			<tr>
-				<th style="width:150px">Name</th>
-				<th style="width:100px">Image</th>
+				<th class="colMedium">Name</th>
+				<th class="colSmall">Image</th>
 				<th>Type</th>
 				<th>Description</th>
 				<th class="score">Match</th>
@@ -84,8 +85,8 @@
 	<table id="hitsTable" cellPadding="3">
 		<tbody>
 			<tr>
-				<th style="width:150px">Name</th>
-				<th style="width:100px">Image</th>
+				<th class="colMedium">Name</th>
+				<th class="colSmall">Image</th>
 				<th>Type</th>
 				<th>Description</th>
 				<th>Subtype</th>

--- a/thefindingofisaac.css
+++ b/thefindingofisaac.css
@@ -7,14 +7,16 @@ body {
     -webkit-background-size: cover;
     -moz-background-size: cover;
     -o-background-size: cover;
-    background-size: cover;	
+    background-size: cover;
     color: #FFFFFF;
+    margin: 0;
+    padding: 8px;
+    box-sizing: border-box;
 }
 table {
 	background-color: #333333;
 	border: 1px solid #000000;
 	border-collapse: collapse;
-	table-layout: fixed;
 	width: 100%;
 }
 th {
@@ -60,6 +62,12 @@ a:hover {
 .editableCell {
 	text-align: left;
 }
+#searchBar {
+	display: block;
+}
+#searchTerms {
+	font-size: 16px;
+}
 #buttonBar {
 	float: right;
 }
@@ -70,4 +78,47 @@ a:hover {
 #resultsCount {
 	font-weight: normal;
 	margin: 4px;
+}
+
+.colMedium {
+	width: 150px;
+}
+.colSmall {
+	width: 100px;
+}
+
+/* Mobile responsive */
+@media screen and (max-width: 600px) {
+	#searchBar {
+		display: block;
+		margin-bottom: 8px;
+	}
+	#searchTerms {
+		width: 100%;
+		box-sizing: border-box;
+	}
+	#buttonBar {
+		float: none;
+		display: flex;
+		flex-wrap: wrap;
+		gap: 4px;
+		margin-bottom: 8px;
+	}
+	table {
+		font-size: 9pt;
+	}
+	th, td {
+		padding: 4px;
+		word-wrap: break-word;
+		overflow-wrap: break-word;
+	}
+	.itemIcon {
+		height: 28px;
+	}
+	.colMedium {
+		width: auto;
+	}
+	.colSmall {
+		width: auto;
+	}
 }

--- a/togglebutton.css
+++ b/togglebutton.css
@@ -2,6 +2,7 @@
     display: inline-block;
     position: relative; width: 90px;
     -webkit-user-select:none; -moz-user-select:none; -ms-user-select: none;
+    flex-shrink: 0;
 }
 .togglebutton-checkbox {
     display: none;


### PR DESCRIPTION
## Summary
- Added viewport meta tag for proper mobile scaling
- Replaced fixed-width table columns with flexible CSS classes
- Added responsive breakpoint (max-width: 600px) that makes the search input full-width, wraps DLC toggle buttons, and adjusts table/icon sizing for small screens

## Test plan
- [x] Open on a mobile device or browser dev tools mobile emulator
- [x] Verify search bar spans full width on narrow screens
- [x] Verify DLC toggle buttons wrap neatly instead of overflowing
- [x] Verify table content is readable without horizontal scrolling
- [x] Confirm desktop layout is unchanged

You can test if everything works properly on https://sarramegnag.github.io/thefindingofisaac/ on your mobile if you want